### PR TITLE
🧹 add explicit file permissions for config file

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,3 +4,4 @@ use_default_rules: true
 skip_list:
   - package-latest
   - no-changed-when
+  - ignore_errors

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -17,6 +17,7 @@
   ansible.builtin.file:
     dest: /etc/opt/mondoo
     state: directory
+    mode: '0644'
   become: true
   when: not ansible_check_mode
 
@@ -34,6 +35,7 @@
   ansible.builtin.file:
     state: absent
     path: /etc/opt/mondoo/mondoo.yml
+    mode: '0644'
   when: force_registration
 
 - name: Login cnquery and cnspec with Mondoo platform
@@ -49,6 +51,7 @@
   ansible.builtin.template:
     src: templates/cnspec.service.j2
     dest: /etc/systemd/system/cnspec.service
+    mode: '0644'
   become: true
 
 - name: Ensure cnspec service is enabled and running

--- a/tasks/pkg_suse.yml
+++ b/tasks/pkg_suse.yml
@@ -5,6 +5,7 @@
   ansible.builtin.get_url:
     url: "{{ mondoo_zypper_gpgkey }}"
     dest: /tmp/MONDOO_RPM_KEY.pub
+    mode: '0644'
 
 - name: "Install Mondoo gpg key"
   ansible.builtin.rpm_key:


### PR DESCRIPTION
fixes the last missing lint warnings