### PR TITLE
⭐ add api_proxy role variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ In addition we support the following variables:
 | ----------------------------- | ------------------------------------------------------------------------- |
 | `force_registration: true`    | set to true if you want to re-register `cnquery` and `cnspec`            |
 | `ensure_managed_client: true` | ensures the configured clients are configured as managed Client in Mondoo |
+| `api_proxy` | Allows setting a Mondoo API proxy setting used only for Mondoo API traffic |
 
 ```yaml
 ---
@@ -96,6 +97,20 @@ If you want to use mondoo behind a proxy
         ensure_managed_client: true
       environment: "{{proxy_env}}"
 ```
+If you want to route only Mondoo API traffic through a specific proxy
+
+```yaml
+---
+- hosts: linux_hosts
+  become: yes
+
+  tasks:
+  - include_role:
+      name: mondoo.client
+    vars:
+      api_proxy: "http://192.168.56.1:3128"
+```
+
 
 1. Run the playbook with the local hosts file
 

--- a/tasks/linux_login.yml
+++ b/tasks/linux_login.yml
@@ -30,6 +30,7 @@
     path: /etc/opt/mondoo/mondoo.yml
     line: "api_proxy: {{ api_proxy }}"
     create: yes
+    mode: '0644'
   become: "{{ use_become }}"
   when: api_proxy != ""
 

--- a/tasks/linux_login.yml
+++ b/tasks/linux_login.yml
@@ -25,6 +25,14 @@
     mode: '0644'
   when: force_registration
 
+- name: Put proxy info if defined
+  ansible.builtin.lineinfile:
+    path: /etc/opt/mondoo/mondoo.yml
+    line: "api_proxy: {{ api_proxy }}"
+    create: yes
+  become: "{{ use_become }}"
+  when: api_proxy != ""
+
 - name: Login cnquery and cnspec with Mondoo platform
   ansible.builtin.command: cnspec login --config /etc/opt/mondoo/mondoo.yml --token {{ registration_token }}
   args:

--- a/tasks/linux_login.yml
+++ b/tasks/linux_login.yml
@@ -21,11 +21,11 @@
     mode: '0644'
   when: force_registration
 
-- name: store cnspec login command as string
+- name: Store cnspec login command as string
   ansible.builtin.set_fact:
     login_cmd: "cnspec login --config /etc/opt/mondoo/mondoo.yml --token {{ registration_token }}"
 
-- name: add api-proxy to cnspec login command
+- name: Add api-proxy to cnspec login command
   ansible.builtin.set_fact:
     login_cmd: "{{ login_cmd + ' --api-proxy ' + api_proxy }}"
   when: api_proxy != ""
@@ -39,7 +39,7 @@
   when: not ansible_check_mode
   notify: Restart cnspec-service
 
-- name: Put proxy info if defined
+- name: Create/update/remove proxy info
   ansible.builtin.lineinfile:
     path: /etc/opt/mondoo/mondoo.yml
     line: "api_proxy: {{ api_proxy }}"

--- a/tasks/linux_login.yml
+++ b/tasks/linux_login.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create mondoo config directory
   ansible.builtin.file:
     dest: /etc/opt/mondoo
@@ -10,9 +9,6 @@
 
 - name: Logout cnquery and cnspec from Mondoo platform
   ansible.builtin.command: cnspec logout --force --config /etc/opt/mondoo/mondoo.yml
-  args:
-    # only run the command if no config file exists
-    creates: /etc/opt/mondoo/mondoo.yml
   when: force_registration
   # if the credentials are already invalid, the command will throw an error
   ignore_errors: true
@@ -25,23 +21,31 @@
     mode: '0644'
   when: force_registration
 
-- name: Put proxy info if defined
-  ansible.builtin.lineinfile:
-    path: /etc/opt/mondoo/mondoo.yml
-    line: "api_proxy: {{ api_proxy }}"
-    create: yes
-    mode: '0644'
-  become: "{{ use_become }}"
+- name: store cnspec login command as string
+  ansible.builtin.set_fact:
+    login_cmd: "cnspec login --config /etc/opt/mondoo/mondoo.yml --token {{ registration_token }}"
+
+- name: add api-proxy to cnspec login command
+  ansible.builtin.set_fact:
+    login_cmd: "{{ login_cmd + ' --api-proxy ' + api_proxy }}"
   when: api_proxy != ""
 
 - name: Login cnquery and cnspec with Mondoo platform
-  ansible.builtin.command: cnspec login --config /etc/opt/mondoo/mondoo.yml --token {{ registration_token }}
-  args:
+  ansible.builtin.command:
+    cmd: "{{ login_cmd }}"
     # only run the command if no config file exists (was not deleted in non-force mode)
     creates: /etc/opt/mondoo/mondoo.yml
   become: "{{ use_become }}"
   when: not ansible_check_mode
   notify: Restart cnspec-service
+
+- name: Put proxy info if defined
+  ansible.builtin.lineinfile:
+    path: /etc/opt/mondoo/mondoo.yml
+    line: "api_proxy: {{ api_proxy }}"
+    regexp: 'api_proxy:'
+    state: "{{ 'present' if api_proxy != '' else 'absent' }}"
+  become: "{{ use_become }}"
 
 - name: Create cnspec systemd service file
   ansible.builtin.template:

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -47,11 +47,11 @@
     path: C:\ProgramData\Mondoo\mondoo.yml
   when: force_registration
 
-- name: store cnspec login command as string
+- name: Store cnspec login command as string
   ansible.builtin.set_fact:
     login_cmd: "cnspec.exe login --config C:\\ProgramData\\Mondoo\\mondoo.yml --token {{ registration_token }}"
 
-- name: add api-proxy to cnspec login command
+- name: Add api-proxy to cnspec login command
   ansible.builtin.set_fact:
     login_cmd: "{{ login_cmd + ' --api-proxy ' + api_proxy }}"
   when: api_proxy != ""
@@ -65,7 +65,7 @@
     creates: C:\ProgramData\Mondoo\mondoo.yml
   when: not ansible_check_mode
 
-- name: Put proxy info if defined
+- name: Create/update/remove proxy info
   ansible.builtin.lineinfile:
     path: C:\ProgramData\Mondoo\mondoo.yml
     line: "api_proxy: {{ api_proxy }}"

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -49,6 +49,14 @@
     path: C:\ProgramData\Mondoo\mondoo.yml
   when: force_registration
 
+- name: Put proxy info if defined
+  ansible.builtin.lineinfile:
+    path: /etc/opt/mondoo/mondoo.yml
+    line: "api_proxy: {{ api_proxy }}"
+    create: yes
+  become: "{{ use_become }}"
+  when: api_proxy != ""
+
 - name: Login cnquery and cnspec
   ansible.windows.win_command: cnspec.exe login --config C:\\ProgramData\\Mondoo\\mondoo.yml --token {{ registration_token }}
   args:

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -51,10 +51,9 @@
 
 - name: Put proxy info if defined
   ansible.builtin.lineinfile:
-    path: /etc/opt/mondoo/mondoo.yml
+    path: C:\ProgramData\Mondoo\mondoo.yml
     line: "api_proxy: {{ api_proxy }}"
     create: yes
-  become: "{{ use_become }}"
   when: api_proxy != ""
 
 - name: Login cnquery and cnspec

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -36,8 +36,6 @@
   ansible.windows.win_command: cnspec.exe logout --force --config C:\\ProgramData\\Mondoo\\mondoo.yml
   args:
     chdir: "C:\\Program Files\\Mondoo"
-    # only run the command if no config file exists
-    creates: C:\ProgramData\Mondoo\mondoo.yml
   when: force_registration
   # if the credentials are already invalid, the command will throw an error
   ignore_errors: true
@@ -49,20 +47,29 @@
     path: C:\ProgramData\Mondoo\mondoo.yml
   when: force_registration
 
+- name: store cnspec login command as string
+  ansible.builtin.set_fact:
+    login_cmd: "cnspec.exe login --config C:\\ProgramData\\Mondoo\\mondoo.yml --token {{ registration_token }}"
+
+- name: add api-proxy to cnspec login command
+  ansible.builtin.set_fact:
+    login_cmd: "{{ login_cmd + ' --api-proxy ' + api_proxy }}"
+  when: api_proxy != ""
+
+- name: Login cnquery and cnspec
+  ansible.windows.win_command:
+    cmd: "{{ login_cmd }}"
+    args:
+      chdir: "C:\\Program Files\\Mondoo"
+    # only run the command if no config file exists (was not deleted in non-force mode)
+    creates: C:\ProgramData\Mondoo\mondoo.yml
+  when: not ansible_check_mode
+
 - name: Put proxy info if defined
   ansible.builtin.lineinfile:
     path: C:\ProgramData\Mondoo\mondoo.yml
     line: "api_proxy: {{ api_proxy }}"
-    create: yes
-  when: api_proxy != ""
-
-- name: Login cnquery and cnspec
-  ansible.windows.win_command: cnspec.exe login --config C:\\ProgramData\\Mondoo\\mondoo.yml --token {{ registration_token }}
-  args:
-    chdir: "C:\\Program Files\\Mondoo"
-    # only run the command if no config file exists (was not deleted in non-force mode)
-    creates: C:\ProgramData\Mondoo\mondoo.yml
-  when: not ansible_check_mode
+    state: "{{ 'present' if api_proxy != '' else 'absent' }}"
 
 - name: Set Mondoo startup mode to auto and ensure it is started
   ansible.windows.win_service:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for mondoo
+# api_proxy can be set to route Mondoo API traffic through the specified proxy
+api_proxy: ""


### PR DESCRIPTION
introduce new `api_proxy` Ansible role variable.

use the `--api-proxy` cli param on login when appropriate

add/update/remove the `api_proxy` setting in the configuration file when appropriate

also: fix up the `creates` param on those ansible.buildin.command. It isn't an `arg` to the command being run, just a parameter for deciding whether or not to run the command (yes, the Ansible docs are wrong)