### PR TITLE
⭐️ add photon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ Make sure jmespath is installed in the same python environment as ansible:
 pip install jmespath
 ```
 
+**I want to test it with an unsupported OS**
+
+Add the following to main.yml and print the ansible_facts to see what is used and adjust the `when` conditions:
+
+```yaml
+- name: Print all available facts
+  ansible.builtin.debug:
+    var: ansible_facts
+```
+
 ## Join the community!
 
 Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -12,6 +12,10 @@
   ansible.builtin.include_tasks: pkg_rhel.yml
   when: ansible_os_family == "RedHat"
 
+- name: Install mondoo package on Photon OS
+  ansible.builtin.include_tasks: pkg_photon.yml
+  when: ansible_os_family == "VMware Photon OS"
+
 - name: Install mondoo package on Suse
   ansible.builtin.include_tasks: pkg_suse.yml
   when: ansible_os_family == "Suse"

--- a/tasks/pkg_photon.yml
+++ b/tasks/pkg_photon.yml
@@ -1,0 +1,20 @@
+# Copyright (c) Mondoo, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+---
+
+- name: Install Mondoo rpm repository
+  ansible.builtin.yum_repository:
+    name: mondoo
+    description: Mondoo Repository
+    baseurl: "{{ mondoo_rpm_repo }}"
+    enabled: yes
+    gpgcheck: true
+    gpgkey: "{{ mondoo_rpm_gpgkey }}"
+  become: "{{ use_become }}"
+  when: not ansible_check_mode
+
+- name: Ensure Mondoo package is installed
+  ansible.builtin.command: tdnf install -y mondoo
+  become: "{{ use_become }}"
+  when: not ansible_check_mode


### PR DESCRIPTION
The normal rpm modules do not work on Photon, therefore we need to fallback on command resource to install the mondoo package via tdnf.