### PR TITLE
🧹 use mondoohq namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This playbook demonstrates how to use the Mondoo Package role to install `cnquer
 - hosts: linux_hosts
   become: yes
   roles:
-    - role: mondoo.client
+    - role: mondoohq.client
       vars:
         registration_token: "changeme"
 ```
@@ -76,7 +76,7 @@ In addition we support the following variables:
 - hosts: linux_hosts
   become: yes
   roles:
-    - role: mondoo.client
+    - role: mondoohq.client
       vars:
         registration_token: "changeme"
         force_registration: true
@@ -96,7 +96,7 @@ If you want to use cnspec behind a proxy
       https_proxy: "http://192.168.56.1:3128"
 
   roles:
-    - role: mondoo.client
+    - role: mondoohq.client
       vars:
         registration_token: "changeme"
         force_registration: true
@@ -108,7 +108,7 @@ If you want to use cnspec behind a proxy
 
 ```bash
 # download mondoo role
-ansible-galaxy install mondoo.client
+ansible-galaxy install mondoohq.client
 # apply the playbook
 ansible-playbook -i hosts playbook.yml
 ```
@@ -139,7 +139,7 @@ If you are targeting windows, the configuration is slightly different since `bec
 ```yaml
 - hosts: windows_hosts
   roles:
-    - role: mondoo.client
+    - role: mondoohq.client
       vars:
         registration_token: "changeme"
         force_registration: false
@@ -149,7 +149,7 @@ If you are targeting windows, the configuration is slightly different since `bec
 
 ```bash
 # download mondoo role
-ansible-galaxy install mondoo.client
+ansible-galaxy install mondoohq.client
 # apply the playbook
 ansible-playbook -i hosts playbook.yml
 ```

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ collections:
 
 galaxy_info:
   role_name: client
-  namespace: mondoo
+  namespace: mondoohq
   github_branch: main
   author: Mondoo, Inc
   description: Install and configure cnquery and cnspec

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,7 @@
 - name: Converge
   hosts: all
   roles:
-    - role: mondoo.client
+    - role: mondoohq.client
       vars:
         registration_token: ""  # not set by default to test package installation in CI/CD
         use_become: false


### PR DESCRIPTION
On Sept. 30, a new version of Ansible Galaxy has been released. See here: https://forum.ansible.com/t/faq-having-issues-with-the-new-galaxy-ng-check-this-before-you-post/1495.

It broke authentication and forgot about our namespace mapping https://github.com/ansible/galaxy/issues/2905. The first step is to get this back to working and then work with ansible team to remove borken stuff from galaxy.