### PR TITLE
🧹 recommend git as source instead of ansible galaxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,12 @@ If you are targeting windows, the configuration is slightly different since `bec
 3. Run the playbook with the local hosts file
 
 ```bash
-# download mondoo role
+# download mondoo role from github
+ansible-galaxy role install git+https://github.com/mondoohq/ansible-mondoo.git
+
+# (alternative) download mondoo role from ansible galaxy
 ansible-galaxy install mondoohq.client
+
 # apply the playbook
 ansible-playbook -i hosts playbook.yml
 ```


### PR DESCRIPTION
Since ansible updated its galaxy a lot of things do not work as expected, see https://forum.ansible.com/t/faq-having-issues-with-the-new-galaxy-ng-check-this-before-you-post/1495. Therefore we change the recommendation for uses to switch to a direct download of the role from github instead of using the role from galaxy.