### PR TITLE
🧹 fix error with os provider for windows installation

### DIFF
--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -35,6 +35,18 @@
     path: "{{ pkg_version_url }}"
     state: present
 
+- name: Get current cnspec version
+  ansible.windows.win_command: cnspec version
+  args:
+    chdir: "C:\\Program Files\\Mondoo"
+  register: cnspec_version
+
+- name: Ensure we have the latest os provider installed
+  ansible.windows.win_command: cnspec providers install os
+  args:
+    chdir: "C:\\Program Files\\Mondoo"
+  when: not ansible_check_mode and cnspec_version.stdout is match(".*cnspec 9.*")
+
 - name: Logout cnquery and cnspec from Mondoo platform
   ansible.windows.win_command: cnspec.exe logout --force --config C:\\ProgramData\\Mondoo\\mondoo.yml
   args:


### PR DESCRIPTION
Can't install or update a windows with this ansible playbook. I always get an error regarding the "provider update", as you can see in the ansible logs:

```powershell
On logout via "cnspec.exe logout --force --config C:\\ProgramData\\Mondoo\\mondoo.yml":
=======================================================================================

WRN could not load configuration file C:\\ProgramData\\Mondoo\\mondoo.yml
Error: could not gather client information: please update the provider plugin for os
Usage:
  cnspec logout [flags]

Aliases:
  logout, unregister

Flags:
      --force   Force re-authentication
  -h, --help    help for logout

Global Flags:
      --api-proxy string   Set proxy for communications with Mondoo API
      --auto-update        Enable automatic provider installation and update (default true)
      --config string      Set config file path (default $HOME/.config/mondoo/mondoo.yml)
      --log-level string   Set log level: error, warn, info, debug, trace (default "info")
  -v, --verbose            Enable verbose output

ERR could not gather client information: please update the provider plugin for os
```

```powershell
On regsiter via "nspec.exe login --config C:\ProgramData\Mondoo\mondoo.yml --token XYZ":
========================================================================================

Error: could not gather client information: please update the provider plugin for os
Usage:
  cnspec login [flags]

Aliases:
  login, register

Flags:
      --annotation stringToString   Set the client annotations. (default [])
      --api-endpoint string         Set the Mondoo API endpoint.
  -h, --help                        help for login
      --name string                 Set asset name.
  -t, --token string                Set a client registration token.

Global Flags:
      --api-proxy string   Set proxy for communications with Mondoo API
      --auto-update        Enable automatic provider installation and update (default true)
      --config string      Set config file path (default $HOME/.config/mondoo/mondoo.yml)
      --log-level string   Set log level: error, warn, info, debug, trace (default "info")
  -v, --verbose            Enable verbose output

ERR could not gather client information: please update the provider plugin for os
```