### PR TITLE
Release on Event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,8 @@
 name: Release Role
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We should only release the role to Galaxy when there is a release.