### PR TITLE
Undefined variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ force_registration: false
 # if 'manual' is set, the user need to set `registration_token`
 registration_token_retrieval: "manual"
 
+timer: ""
+
 # annotation/ tags for the node
 annotations: ""
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ force_registration: false
 registration_token_retrieval: "manual"
 
 timer: ""
+splay: ""
 
 # annotation/ tags for the node
 annotations: ""


### PR DESCRIPTION
With the undefined variables `timer` and `splay` the current defined role is not able to run.
I just added their definition to the default variables, so that a play using the role can run through