### PR TITLE
Add support for subscription-manager

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,8 @@ mondoo_deb_gpgkey: "https://releases.mondoo.com/debian/pubkey.gpg"
 mondoo_deb_gpgkey_dest: "/usr/share/keyrings/mondoo-archive-keyring.gpg"
 
 # yum repo and keys
+# 'mondoo_subscription_manager_repo_id' explicitly excludes 'mondoo_rpm_*'
+mondoo_subscription_manager_repo_id: ""
 mondoo_rpm_repo: "https://releases.mondoo.com/rpm/$basearch/"
 mondoo_rpm_gpgkey: "https://releases.mondoo.com/rpm/pubkey.gpg"
 

--- a/tasks/pkg_rhel.yml
+++ b/tasks/pkg_rhel.yml
@@ -3,6 +3,13 @@
 
 ---
 
+- name: Enable repository via subscription-manager
+  community.general.rhsm_repository:
+    name: "{{ mondoo_subscription_manager_repo_id }}"
+    state: enabled
+  become: "{{ use_become }}"
+  when: mondoo_subscription_manager_repo_id | length > 0
+
 - name: Install Mondoo rpm repository
   ansible.builtin.yum_repository:
     name: mondoo
@@ -12,7 +19,10 @@
     gpgcheck: true
     gpgkey: "{{ mondoo_rpm_gpgkey }}"
   become: "{{ use_become }}"
-  when: not ansible_check_mode
+  when:
+    - not ansible_check_mode
+    - mondoo_subscription_manager_repo_id is undefined or
+      mondoo_subscription_manager_repo_id | length > 0
 
 - name: Ensure Mondoo package is installed
   ansible.builtin.yum:


### PR DESCRIPTION
This merge request adds support to enable/manage the rpm repository via `subscription-manager` command.